### PR TITLE
Adds repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.9",
   "description": "Library to build Sequelize models using ES6 code",
   "main": "index.js",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/ConciergeAuctions/sequelize-six"
+  },
   "scripts": {
     "test": "mocha --compilers js:babel/register",
     "build": "babel src -d lib",


### PR DESCRIPTION
From the npm docs.

"Specify the place where your code lives. This is helpful for people who want to contribute. If the git repo is on GitHub, then the npm docs command will be able to find you."